### PR TITLE
fix: remove the name of the participant from top

### DIFF
--- a/Symbl-Powered-Agora-master/src/pages/VideoCall.tsx
+++ b/Symbl-Powered-Agora-master/src/pages/VideoCall.tsx
@@ -214,7 +214,7 @@ const VideoCall: React.FC = () => {
                 >
                   {callActive ? (
                     <View style={style.full}>
-                      <div id="username">{username}</div>
+                      <div id="username" style={{display:"none"}}>{username}</div>
 
                       <Navbar
                         participantsView={participantsView}


### PR DESCRIPTION
# Removed the name of the participant from top left corner of screen

![](https://user-images.githubusercontent.com/35089751/135984404-d7fa2e8f-7794-4643-977e-8e320a0c76de.png)

* closes #18 