### PR TITLE
fix(PR-15) :- Displayed the Transcript tab by default when Transcript panel is opened

### DIFF
--- a/Symbl-Powered-Agora-master/src/subComponents/SymblTranscript.tsx
+++ b/Symbl-Powered-Agora-master/src/subComponents/SymblTranscript.tsx
@@ -92,7 +92,7 @@ export default function SymblTranscript(props: any) {
     username,
   } = props;
   const [insightActive, setInsightActive] = useState(false);
-  const [transcriptActive, setTranscriptActive] = useState(false);
+  const [transcriptActive, setTranscriptActive] = useState(true);
   const [topicActive, setTopicActive] = useState(false);
   const [intermediateTranscript, setIntermediateTranscript] = useState('');
 


### PR DESCRIPTION


## Type of Pull Request 
> Check all applicable

- [ ] 🎉 Feature Enhancement
- [X] 🐛 Bug Fix
- [ ] 📖 Documentation Update
- [ ] ❇️ Other

## Description
> Displayed the Transcript tab by default when Transcript Panel is opened.

## Issue
> Neither transcript, nor insights, nor topics tab is selected by default. It just shows an empty panel.


